### PR TITLE
Fix alerting by ranging over alerts in webhooks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,4 @@ alertmanager_irc_relay_irc_nickname_password: ""
 alertmanager_irc_relay_irc_realname: ""
 
 alertmanager_irc_relay_notice_once_per_alert_group: "yes"
-alertmanager_irc_relay_notice_template: "{% raw %}Alert {{ .Labels.alertname }} on {{ .Labels.instance }} is {{ .Status }}{% endraw %}"
+alertmanager_irc_relay_notice_template: "{% raw %}{{ range .Alerts }}Alert {{ .Labels.alertname }} on {{ .Labels.instance }} is {{ .Status }}{{ end }}{% endraw %}"


### PR DESCRIPTION
We need to range over the `.Alerts` to make the template work.
This is still being tested, so hold on merging things for now.

/cc @SuperQ @gouthamve @paulfantom 