### PR TITLE
include -> include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,15 @@
 ---
-- include: preflight.yml
+- ansible.builtin.include_tasks: preflight.yml
   tags:
     - alertmanager_irc_relay_install
     - alertmanager_irc_relay_configure
     - alertmanager_irc_relay_run
 
-- include: install.yml
-  become: true
+- ansible.builtin.include_tasks: install.yml
   tags:
     - alertmanager_irc_relay_install
 
-- include: configure.yml
-  become: true
+- ansible.builtin.include_tasks: configure.yml
   tags:
     - alertmanager_irc_relay_configure
 


### PR DESCRIPTION
> This module has been removed in a major release after 2023-05-16 of ansible.builtin. Use include_tasks or import_tasks instead.

REF: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_module.html